### PR TITLE
Allow developer to external access to plugin instance

### DIFF
--- a/simpleshop-cz.php
+++ b/simpleshop-cz.php
@@ -29,4 +29,4 @@ define( 'SIMPLESHOP_PREFIX', '_ssc_' );
 /**
  * Start plugin
  */
-new Loader();
+new Plugin();

--- a/simpleshop-cz.php
+++ b/simpleshop-cz.php
@@ -29,4 +29,4 @@ define( 'SIMPLESHOP_PREFIX', '_ssc_' );
 /**
  * Start plugin
  */
-new Plugin();
+SimpleShop::getInstance();

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -13,11 +13,11 @@ use Redbit\SimpleShop\WpPlugin\Vyfakturuj\VyfakturujAPI;
 class Admin {
 
 	/**
-	 * @var Loader
+	 * @var Plugin
 	 */
 	private $loader;
 
-	public function __construct(Loader $loader) {
+	public function __construct(Plugin $loader) {
 		$this->loader = $loader;
 
 		add_action( 'admin_menu', [ $this, 'add_settings_page' ] );

--- a/src/Cron.php
+++ b/src/Cron.php
@@ -10,11 +10,11 @@ namespace Redbit\SimpleShop\WpPlugin;
 
 class Cron {
 	/**
-	 * @var Loader
+	 * @var Plugin
 	 */
 	private $loader;
 
-	public function __construct(Loader $loader) {
+	public function __construct(Plugin $loader) {
 		$this->loader = $loader;
 
 		if ( ! wp_next_scheduled( 'ssc_send_user_has_access_to_post_notification' ) ) {

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @package Redbit\SimpleShop\WpPlugin
+ * @license MIT
+ * @copyright 2016-2018 Redbit s.r.o.
+ * @author Redbit s.r.o. <info@simpleshop.cz>
+ */
+
+namespace Redbit\SimpleShop\WpPlugin;
+
+/**
+ * Back-compatibility of deprecated plugin loader
+ * @package Redbit\SimpleShop\WpPlugin
+ */
+class Loader {
+	public function __construct() {
+		$class = SimpleShop::class;
+		trigger_error(
+			"Manually start of plugin is deprecated, use '$class::getInstance()' instead",
+			E_USER_DEPRECATED
+		);
+	}
+
+	/**
+	 * @param string $method
+	 * @param array $arguments
+	 *
+	 * @return mixed
+	 */
+	public function __call( $method, array $arguments ) {
+		$currentClass = self::class;
+		$class        = SimpleShop::class;
+		trigger_error(
+			"'$currentClass' is deprecated, use '$class::getInstance()->$method()' instead",
+			E_USER_DEPRECATED
+		);
+
+		return call_user_func_array( [ SimpleShop::getInstance(), $method ], $arguments );
+	}
+}

--- a/src/Metaboxes.php
+++ b/src/Metaboxes.php
@@ -12,11 +12,11 @@ class Metaboxes {
 	public $prefix = '_ssc_';
 
 	/**
-	 * @var Loader
+	 * @var Plugin
 	 */
 	private $loader;
 
-	public function __construct(Loader $loader) {
+	public function __construct(Plugin $loader) {
 		$this->loader = $loader;
 		add_action( 'cmb2_admin_init', [ $this, 'page_metaboxes' ] );
 		add_action( 'cmb2_admin_init', [ $this, 'user_metaboxes' ] );

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -140,7 +140,7 @@ class Plugin {
 				'simpleshop-cz' ), E_USER_ERROR );
 		}
 
-		// Generate and save the secure key$this = new Plugin();
+		// Generate and save the secure key
 		$key = $this->generate_secure_key();
 		$this->save_secure_key( $key );
 	}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -8,7 +8,7 @@
 
 namespace Redbit\SimpleShop\WpPlugin;
 
-class Loader {
+class Plugin {
 	/**
 	 * @var string
 	 */
@@ -140,7 +140,7 @@ class Loader {
 				'simpleshop-cz' ), E_USER_ERROR );
 		}
 
-		// Generate and save the secure key$this = new Loader();
+		// Generate and save the secure key$this = new Plugin();
 		$key = $this->generate_secure_key();
 		$this->save_secure_key( $key );
 	}

--- a/src/Rest.php
+++ b/src/Rest.php
@@ -11,11 +11,11 @@ namespace Redbit\SimpleShop\WpPlugin;
 class Rest extends \WP_REST_Controller {
 
 	/**
-	 * @var Loader
+	 * @var Plugin
 	 */
 	private $loader;
 
-	public function __construct( Loader $loader ) {
+	public function __construct( Plugin $loader ) {
 		$this->loader = $loader;
 
 		add_action( 'rest_api_init', [ $this, 'register_routes' ] );

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -44,17 +44,19 @@ class Settings {
 	 */
 	private $metabox_id = 'ssc_option_metabox';
 	/**
-	 * @var Loader
+	 * @var Plugin
 	 */
 	private $loader;
 
 	/**
 	 * Constructor
+	 *
+	 * @param Plugin $loader
+	 *
 	 * @since 0.1.0
 	 *
-	 * @param Loader $loader
 	 */
-	public function __construct( Loader $loader ) {
+	public function __construct( Plugin $loader ) {
 		// Set our title
 		$this->title = 'Settings';
 		$this->register_hooks();

--- a/src/SimpleShop.php
+++ b/src/SimpleShop.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @package Redbit\SimpleShop\WpPlugin
+ * @license MIT
+ * @copyright 2016-2019 Redbit s.r.o.
+ * @author Redbit s.r.o. <info@simpleshop.cz>
+ */
+
+namespace Redbit\SimpleShop\WpPlugin;
+
+class SimpleShop {
+	/**
+	 * @var Plugin|null
+	 */
+	private static $instance;
+
+	/**
+	 * @return Plugin
+	 */
+	public static function getInstance() {
+		if ( self::$instance === null ) {
+			self::$instance = self::factory();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * @return Plugin
+	 */
+	protected static function factory() {
+		return new Plugin();
+	}
+}


### PR DESCRIPTION
- Instead create new instance by `new Loader()` use new instance container `Simpleshop::getInstance()`.
- It makes container to prevent re-create it twice.
- Developer still can force create new instance via argument `$instanceId` (`Simpleshop::getInstance('test')`).
- Added back compatibility for case developer already using `new Loader()` access.

Closes #20