### PR TITLE
Ability to testable SS API endpoint

### DIFF
--- a/src/Admin.php
+++ b/src/Admin.php
@@ -55,7 +55,7 @@ class Admin {
 	public function get_simpleshop_products() {
 		$values = [];
 		if ( $this->loader->has_credentials() ) {
-			$vyfakturuj_api = new VyfakturujAPI( $this->loader->get_api_email(), $this->loader->get_api_key() );
+			$vyfakturuj_api = $this->loader->get_api_client();
 			$ret            = $vyfakturuj_api->getProducts();
 
 			if ( $ret ) {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -8,6 +8,8 @@
 
 namespace Redbit\SimpleShop\WpPlugin;
 
+use Redbit\SimpleShop\WpPlugin\Vyfakturuj\VyfakturujAPI;
+
 class Plugin {
 	/**
 	 * @var string
@@ -178,5 +180,25 @@ class Plugin {
 
 	public function get_plugin_main_file() {
 		return $this->pluginMainFile;
+	}
+
+	/**
+	 * @param string|null $overrideLogin
+	 * @param string|null $overrideApiKey
+	 * @return VyfakturujAPI
+	 * @throws \VyfakturujAPIException
+	 */
+	public function get_api_client( $overrideLogin = null, $overrideApiKey = null ) {
+		$email  = $overrideLogin !== null ? $overrideLogin : $this->get_api_email();
+		$apiKey = $overrideApiKey !== null ? $overrideApiKey : $this->get_api_key();
+
+		$client = new VyfakturujAPI( $email, $apiKey );
+
+		$endpointUrl = $this->settings->ssc_get_option( 'ssc_api_endpoint_url' );
+		if(empty($endpointUrl) === false) {
+			$client->setEndpointUrl($endpointUrl);
+		}
+
+		return $client;
 	}
 }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -357,7 +357,7 @@ SimpleShop.cz - <i>S námi zvládne prodávat každý</i>',
 			$api_key = sanitize_text_field( $_POST['ssc_api_key'] );
 		}
 
-		$vyfakturuj_api = new VyfakturujAPI( $api_email, $api_key );
+		$vyfakturuj_api = $this->loader->get_api_client( $api_email, $api_key );
 		$result         = $vyfakturuj_api->initWPPlugin( site_url() );
 		if ( isset( $result['status'] ) && $result['status'] == 'success' ) {
 			update_option( 'ssc_valid_api_keys', 1 );

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -253,6 +253,16 @@ SimpleShop.cz - <i>S námi zvládne prodávat každý</i>',
 
 		$cmb->add_field(
 			[
+				'name' => __( 'SimpleShop API Endpoint URL', 'simpleshop-cz' ),
+				'desc' => __( '[SERVICE FLAG] You can here override URL to SimpleShop API. Leave blank to use default API.', 'simpleshop-cz' ),
+				'id'   => 'ssc_api_endpoint_url',
+				'type' => 'text',
+				'classes_cb' => [ $this, 'show_endpoint_url_when_flagged' ],
+			]
+		);
+
+		$cmb->add_field(
+			[
 				'name'       => 'Obecná nastavení',
 				'type'       => 'title',
 				'id'         => 'ssc_general_settings_title',
@@ -373,6 +383,14 @@ SimpleShop.cz - <i>S námi zvládne prodávat každý</i>',
 	function is_valid_api_keys() {
 		// If the keys are valid, do nothing
 		if ( get_option( 'ssc_valid_api_keys' ) == 1 ) {
+			return [];
+		}
+
+		return [ 'hidden' ];
+	}
+
+	public function show_endpoint_url_when_flagged() {
+		if ( $_GET['edit_url_endpoint'] == 'yes' ) {
 			return [];
 		}
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -157,7 +157,7 @@ class Settings {
 		$cmb->add_field(
 			[
 				'name'       => 'Nastavení e-mailu, který se posílá novým členům:',
-				'classes_cb' => [ $this, 'is_valid_api_keys' ],
+				'classes_cb' => [ $this, 'hide_when_invalid_keys' ],
 				'type'       => 'title',
 				'id'         => 'ssc_email_title',
 			]
@@ -168,7 +168,7 @@ class Settings {
 				'id'               => 'ssc_email_enable',
 				'type'             => 'select',
 				'show_option_none' => false,
-				'classes_cb'       => [ $this, 'is_valid_api_keys' ],
+				'classes_cb'       => [ $this, 'hide_when_invalid_keys' ],
 				'default'          => '1',
 				'options'          => [
 					'1' => __( 'Yes, send email to new member.', 'cmb2', 'simpleshop.cz', 'simpleshop-cz' ),
@@ -181,7 +181,7 @@ class Settings {
 				'name'       => __( 'Email subject', 'simpleshop-cz' ),
 //            'desc' => __('Najdete ho ve svém SimpleShop účtu v Nastavení -> WP Plugin','ssc'),
 				'id'         => 'ssc_email_subject',
-				'classes_cb' => [ $this, 'is_valid_api_keys' ],
+				'classes_cb' => [ $this, 'hide_when_invalid_keys' ],
 				'type'       => 'text',
 				'default'    => 'Byl Vám udělen přístup do členské sekce',
 			]
@@ -201,7 +201,7 @@ class Settings {
 				                    . '', 'simpleshop-cz' ),
 				'id'         => 'ssc_email_text',
 				'type'       => 'wysiwyg',
-				'classes_cb' => [ $this, 'is_valid_api_keys' ],
+				'classes_cb' => [ $this, 'hide_when_invalid_keys' ],
 				'default'    => 'Dobrý den,
 byl udělen přístup do členské sekce.
 
@@ -226,7 +226,7 @@ SimpleShop.cz - <i>S námi zvládne prodávat každý</i>',
 			[
 				'name' => 'Nastavení API - propojení s aplikací SimpleShop:',
 //            'desc' => 'This is a title description',
-//            'show_on_cb' => array($this,'is_valid_api_keys'),
+//            'show_on_cb' => array($this,'hide_when_invalid_keys'),
 				'type' => 'title',
 				'id'   => 'ssc_api_title',
 			]
@@ -266,7 +266,7 @@ SimpleShop.cz - <i>S námi zvládne prodávat každý</i>',
 				'name'       => 'Obecná nastavení',
 				'type'       => 'title',
 				'id'         => 'ssc_general_settings_title',
-				'classes_cb' => [ $this, 'is_valid_api_keys' ],
+				'classes_cb' => [ $this, 'hide_when_invalid_keys' ],
 			]
 		);
 
@@ -275,7 +275,7 @@ SimpleShop.cz - <i>S námi zvládne prodávat každý</i>',
 				'name'       => 'Přesměrování po přihlášení',
 				'type'       => 'text',
 				'id'         => 'ssc_redirect_url',
-				'classes_cb' => [ $this, 'is_valid_api_keys' ],
+				'classes_cb' => [ $this, 'hide_when_invalid_keys' ],
 			]
 		);
 		$cmb->add_field(
@@ -283,7 +283,7 @@ SimpleShop.cz - <i>S námi zvládne prodávat každý</i>',
 				'name'       => 'Přesměrování po přihlášení',
 				'type'       => 'text',
 				'id'         => 'ssc_redirect_url',
-				'classes_cb' => [ $this, 'is_valid_api_keys' ],
+				'classes_cb' => [ $this, 'hide_when_invalid_keys' ],
 			]
 		);
 		$cmb->add_field(
@@ -291,7 +291,7 @@ SimpleShop.cz - <i>S námi zvládne prodávat každý</i>',
 				'name'       => 'Odebrat zabezpečené z RSS',
 				'type'       => 'checkbox',
 				'id'         => 'ssc_hide_from_rss',
-				'classes_cb' => [ $this, 'is_valid_api_keys' ],
+				'classes_cb' => [ $this, 'hide_when_invalid_keys' ],
 			]
 		);
 
@@ -301,7 +301,7 @@ SimpleShop.cz - <i>S námi zvládne prodávat každý</i>',
 				'name'       => 'Odebrat propojení',
 				'type'       => 'title',
 				'id'         => 'ssc_remove_api_title',
-				'classes_cb' => [ $this, 'is_valid_api_keys' ],
+				'classes_cb' => [ $this, 'hide_when_invalid_keys' ],
 			]
 		);
 
@@ -311,7 +311,7 @@ SimpleShop.cz - <i>S námi zvládne prodávat každý</i>',
 				'desc'       => __( 'You found it at SimpleShop in Settings (Nastavení) -> WP Plugin', 'simpleshop-cz' ),
 				'id'         => 'ssc_api_disconnect',
 				'type'       => 'disconnect_button',
-				'classes_cb' => [ $this, 'is_valid_api_keys' ],
+				'classes_cb' => [ $this, 'hide_when_invalid_keys' ],
 			]
 		);
 	}
@@ -380,7 +380,7 @@ SimpleShop.cz - <i>S námi zvládne prodávat každý</i>',
 	 * but previously the fields were removed completely from the form, so the default values were not saved until the API keys were in place
 	 * @return array
 	 */
-	function is_valid_api_keys() {
+	public function hide_when_invalid_keys() {
 		// If the keys are valid, do nothing
 		if ( get_option( 'ssc_valid_api_keys' ) == 1 ) {
 			return [];


### PR DESCRIPTION
Občas potřebujeme testovat Wordpress plugin proti jinému serveru než produkci a potřebujeme tedy změnit URL na testovací API endpoint. Zkusil jsem proto upravit plugin, aby bylo možné nastavit vlastní URL API endpointu.

Ale aby to nemátlo uživatele, je nastavení URL schováno tak a zobrazí se jen při zadání parametru `edit_url_endpoint` do URL, např.:
`/wp-admin/admin.php?page=ssc_options&edit_url_endpoint=yes`

Nevím, zda je to ideální, popř. zda k tomu WP neposkytuje nějaké lepší metody, kde číst parametry z URL. Pokud existují, tak mi to klidně omlaťte o hlavu, od toho to PR děláme :)

Pokud by z kódu nebyl zřejmý záměr, podívejte se na jednotlivé commity, ty jsou mnohem menší a srozumitelnější.