### PR TITLE
Product refresh

### DIFF
--- a/languages/simpleshop-cz-cs_CZ.po
+++ b/languages/simpleshop-cz-cs_CZ.po
@@ -203,7 +203,7 @@ msgid "Yes, send email to new member."
 msgstr "Ano, poslat každému novému členovi e-mail."
 
 #: src/Settings.php:152
-msgid "No, doesn't send email to new members."
+msgid "No, don't send email to new members."
 msgstr "Ne, zakázat posílání e-mailu novým členům."
 
 #: src/Settings.php:156

--- a/src/Gutenberg.php
+++ b/src/Gutenberg.php
@@ -32,10 +32,7 @@ class Gutenberg {
 	}
 
 	function load_products() {
-		if ( ! get_option( 'simpleshop_products' ) ) {
-			update_option( 'simpleshop_products', $this->admin->get_simpleshop_products() );
-
-		}
+		$this->admin->get_simpleshop_products();
 	}
 
 	function load_block_assets() { // phpcs:ignore
@@ -61,7 +58,7 @@ class Gutenberg {
 			'simpleshop-gutenberg-block-js',
 			'ssGutenbergVariables',
 			[
-				'products' => get_option( 'simpleshop_products', [] ),
+				'products' => $this->load_products(),
 				'groups'   => $this->group->get_groups(),
 			]
 		);

--- a/src/Gutenberg.php
+++ b/src/Gutenberg.php
@@ -31,11 +31,11 @@ class Gutenberg {
 		$this->pluginDirUrl = plugin_dir_url($pluginMainFile);
 	}
 
-	function load_products() {
+	public function load_products() {
 		$this->admin->get_simpleshop_products();
 	}
 
-	function load_block_assets() { // phpcs:ignore
+	public function load_block_assets() { // phpcs:ignore
 
 		// Register block styles for both frontend + backend.
 		wp_register_style(
@@ -96,6 +96,8 @@ class Gutenberg {
 	 *
 	 * @param $content
 	 * @param $block
+	 *
+	 * @return string
 	 */
 	public function maybe_hide_block( $content, $block ) {
 		$args = [

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -90,6 +90,11 @@ class Plugin {
 		return $this->settings->ssc_get_option( 'ssc_api_email' );
 	}
 
+	/** @return string|null Cache key related to API identity, or null when unlogged */
+	public function get_cache_user_key() {
+		return $this->email ? md5( strtolower( $this->email ) ) : null;
+	}
+
 	public function get_api_email() {
 		return $this->email;
 	}

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -172,7 +172,7 @@ class Settings {
 				'default'          => '1',
 				'options'          => [
 					'1' => __( 'Yes, send email to new member.', 'cmb2', 'simpleshop.cz', 'simpleshop-cz' ),
-					'2' => __( 'No, doesn\'t send email to new members.', 'cmb2', 'simpleshop.cz', 'simpleshop-cz' ),
+					'2' => __( 'No, don\'t send email to new members.', 'cmb2', 'simpleshop.cz', 'simpleshop-cz' ),
 				],
 			]
 		);


### PR DESCRIPTION
@mhladka při testování objevila, že se neobnovují produkty.

V kódu jsem našel, že načítání produktů naní napříč pluginem konzistentní, stejně tak přístup k cache:
- pojmenování klíče option, do kterého se produkty ukládaly (`simpleshop_products`, cále jen „cache“) nebyla v souladu s tvarem ostatních klíčů (prefix `ssc_`…),
- někdy se produkty tahaly přímo z API bez ohledu na cache,
- někdy se produkty naopak tahaly z cache bez ohledu na přihlášeného uživatele,
- v mnoha případech se produkty neaktuzalizovaly mnoho let.

## Navrhuji úpravu
- přístup k produktům napříč pluginem je přes metodu `\Redbit\SimpleShop\WpPlugin\Admin::get_simpleshop_products()`, která použije cache, přičemž ověří, že cache je opravu pro danou firmu a není starší než 24 hodin (to je k dizkuzi), jinak si automaticky stáhne produkty z API,
- aktualizace cache produktů se dá vynutit voláním `\Redbit\SimpleShop\WpPlugin\Admin::update_simpleshop_products_cache()`,
- všechny místa v pluginu byly sjednoceny, aby používaly toto rozhraní.

### Možné problémy
K diskuzi je metoda `\Redbit\SimpleShop\WpPlugin\Admin::wp_ajax_load_simple_shop_products()`, protože tato si **vždy načetla data z API** a aktualizovala cache, nicméně po mojí úpravě **používá poslušně cache**. 
https://github.com/redbitcz/simpleshop-wp-plugin/blob/77f7b8f49bc872c19b51fcd7b249fd0c85478015/src/Admin.php#L49-L54
Nenašel jsem kde se volá (rspt. je tam callback z WP action, ale nenašel jsem, kde se volá ten) a domnívám se, že jde o mrtvý kód. @vasikgreif prosím zvažte, jaký to může mít dopad, případně stačí odkomentovat jeden řádek a bude si zase načítat data z API pokaždé.

Otázkou, co je požadováno.