### PR TITLE
Gutenberg: Fix support with WP < v5

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -71,6 +71,15 @@ class Plugin {
 		new Cron( $this );
 		new Metaboxes( $this );
 		new Shortcodes($this->access);
+		$this->init_gutenberg();
+	}
+
+	private function init_gutenberg() {
+		if(function_exists('register_block_type') === false) {
+			// Skip init Gutenberg features - Gurenberg not supported in WP
+			return;
+		}
+
 		new Gutenberg($this->admin, $this->group, $this->access, $this->pluginMainFile);
 	}
 


### PR DESCRIPTION
Pro WP < `v5` chceme zachovat podporu. Nyní ale plugin shodí celý WP, protože natvrdo vyžaduje funkce z WP 5.

Tento PR podmiňuje načtení podpory Gutenberg funkcí pouze tehdy, pokud jsou dostupné potřebné metody. Lepší test jsem nenašel (viz např.: https://wordpress.org/support/topic/check-if-page-is-using-gutenberg-or-if-content-is-in-a-block/ kde se podpora Gutenbergu testuje hledáním HTML komentáře v obsahu stránky ... WTF???)