### PR TITLE
Login regirects - bypass HTTP cache

### DIFF
--- a/src/Access.php
+++ b/src/Access.php
@@ -75,6 +75,7 @@ class Access {
 
 		// If the post is protected and user is not logged in, redirect him to login
 		if ( $post_groups && ! is_user_logged_in() ) {
+			nocache_headers();
 			wp_safe_redirect( wp_login_url( site_url( $_SERVER['REQUEST_URI'] ) ) );
 			exit();
 		}
@@ -85,6 +86,7 @@ class Access {
 
 			$main_redirect_url = is_user_logged_in() ? site_url() : wp_login_url();
 			$url               = $no_access_url ?: $main_redirect_url;
+			nocache_headers();
 			wp_redirect( $url );
 			exit();
 		}


### PR DESCRIPTION
Při přihlašování je přesměrování ovlivněno cachí browseru, potlačeno hlavičkou Expires v response.

Vytvořil @vasikgreif – PR pouze pro evidenci