### PR TITLE
Drobná vylepšení, překlady

### DIFF
--- a/js/gutenberg/ss-gutenberg.js
+++ b/js/gutenberg/ss-gutenberg.js
@@ -142,15 +142,6 @@ const withInspectorControls = createHigherOrderComponent((BlockEdit) => {
                                 });
                             }}
                         />
-                        <TextControl
-                            label={__('Days to view', 'simpleshop-cz')}
-                            value={simpleShopDaysToView}
-                            onChange={(selectedSpacingOption) => {
-                                props.setAttributes({
-                                    simpleShopDaysToView: selectedSpacingOption
-                                });
-                            }}
-                        />
                         <ToggleControl
                             label={__('Ignore date limits', 'simpleshop-cz')}
                             help={__('Check to completely disable limiting post access by date', 'simpleshop-cz')}

--- a/js/gutenberg/ss-gutenberg.js
+++ b/js/gutenberg/ss-gutenberg.js
@@ -51,15 +51,15 @@ addFilter('blocks.registerBlockType', 'simpleshop/attributes/custom', addSimpleS
 
 const simpleShopYesNoSelect = [
     {
-        label: 'Choose',
+        label: __('Choose', 'simpleshop-cz'),
         value: ''
     },
     {
-        label: 'Yes',
+        label: __('Yes', 'simpleshop-cz'),
         value: 'yes'
     },
     {
-        label: 'No',
+        label: __('No', 'simpleshop-cz'),
         value: 'no'
     }
 ];
@@ -99,7 +99,7 @@ const withInspectorControls = createHigherOrderComponent((BlockEdit) => {
                 <BlockEdit {...props} />
                 <InspectorControls>
                     <PanelBody
-                        title={__('Simpleshop Settings')}
+                        title={__('SimpleShop Settings', 'simpleshop-cz')}
                         initialOpen={true}
                     >
                         <p><a href="https://podpora.redbit.cz/stitek/wp-plugin/">{__('Help - SimpleShop plugin','simpleshop-cz')}</a></p>
@@ -249,14 +249,14 @@ const EditSimpleShop = (props) => {
                         <>
                             <SelectControl
                                 className={'simpleshop-form-select'}
-                                label={__('Form')}
-                                description={__('Select the SimpleShop Form')}
+                                label={__('Form', 'simpleshop-cz')}
+                                description={__('Select the SimpleShop Form', 'simpleshop-cz')}
                                 options={products}
                                 value={attributes.ssFormId}
                                 onChange={(ssFormId) => setAttributes({ssFormId})}
                             />
                             <Button onClick={() => reloadProducts()}>
-                                {__('Reload forms')}
+                                {__('Reload forms', 'simpleshop-cz')}
                             </Button>
                         </> : <>Loading</>
                     }
@@ -270,12 +270,12 @@ const SaveSimpleShop = () => null;
 
 
 registerBlockType('simpleshop/simpleshop-form', {
-    title: __('SimpleShop Form'),
+    title: __('SimpleShop Form', 'simpleshop-cz'),
     icon: 'shield',
     category: 'common',
     keywords: [
-        __('SimpleShop'),
-        __('form'),
+        __('SimpleShop', 'simpleshop-cz'),
+        __('Form', 'simpleshop-cz'),
     ],
     edit: EditSimpleShop,
     save: SaveSimpleShop,

--- a/js/gutenberg/v1.js
+++ b/js/gutenberg/v1.js
@@ -2,7 +2,7 @@ export default {
   attributes: {
     ssFormId: {
       type: 'string',
-      default: 'Choose form'
+      default: __('Choose form', 'simpleshop-cz')
     },
   },
   save: function ({ attributes, className }) {

--- a/simpleshop-cz.php
+++ b/simpleshop-cz.php
@@ -14,7 +14,6 @@
  * Author URI: https://www.redbit.cz
  * Version: dev-master
  * Text Domain: simpleshop-cz
- * Domain Path: /languages
  * Requires at least: 4.6
  */
 

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -40,7 +40,7 @@ class Admin {
 	}
 
 	/**
-	 * Get products from simple shop via API
+	 * Get products from SimpleShop via API
 	 * TODO: Show message if loading pf products failed
 	 */
 	public function wp_ajax_load_simple_shop_products() {

--- a/src/Group.php
+++ b/src/Group.php
@@ -115,6 +115,6 @@ class Group {
 
 		$groups = $this->get_user_groups( $user_id );
 
-		return in_array( $this->id, $groups ) ? true : false;
+		return in_array( $this->id, $groups );
 	}
 }

--- a/src/Metaboxes.php
+++ b/src/Metaboxes.php
@@ -95,13 +95,6 @@ class Metaboxes {
 				]
 			);
 
-//            $cmb->add_field(array(
-//                'name' => __('Přesměrovat na přihlášení', 'ssc'),
-//                'desc' => __('Zaškrtněte, pokud chcete uživatele přesměrovat na přihlašovací formulář. Po přihlášení bude uživatel přesměrován zpět na tuto stránku.', 'ssc'),
-//                'id' => $this->prefix . 'no_access_redirect_to_login_form',
-//                'type' => 'checkbox'
-//            ));
-
 
 			$cmb->add_field(
 				[
@@ -195,7 +188,7 @@ class Metaboxes {
         <table id="custom_user_field_table" class="form-table">
             <tr id="simpleshop__groups">
                 <th>
-                    <label for="custom_field"><?php _e( 'Simpleshop Groups', 'simpleshop-cz' ); ?></label>
+                    <label for="custom_field"><?php _e( 'SimpleShop Groups', 'simpleshop-cz' ); ?></label>
                 </th>
                 <td>
                     <table>

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -85,7 +85,7 @@ class Settings {
 		printf(
 			'<a href="%s">%s</a>',
 			htmlspecialchars( admin_url( 'admin.php?page=ssc_options&disconnect_simpleshop=1' ), ENT_QUOTES ),
-			__( 'Disconnect Simple Shop', 'simpleshop-cz' )
+			__( 'Disconnect SimpleShop', 'simpleshop-cz' )
 		);
 	}
 
@@ -109,7 +109,7 @@ class Settings {
 			$translatedTitle,
 			$translatedTitle,
 			'manage_options',
-			'admin.php?page=' . $this->key,
+			'admin.php?page=' . urlencode( $this->key ),
 			[ $this, 'admin_page_display' ]
 		);
 
@@ -131,10 +131,10 @@ class Settings {
 	 */
 	public function admin_page_display() {
 		?>
-		<div class="wrap cmb2-options-page <?php echo $this->key; ?>">
-			<h2><?php echo esc_html( get_admin_page_title() ); ?></h2>
+        <div class="wrap cmb2-options-page <?php echo $this->key; ?>">
+            <h2><?php echo esc_html( get_admin_page_title() ); ?></h2>
 			<?php cmb2_metabox_form( $this->metabox_id, $this->key ); ?>
-		</div>
+        </div>
 		<?php
 	}
 
@@ -165,7 +165,7 @@ class Settings {
 		#
 		$cmb->add_field(
 			[
-				'name'       => 'Nastavení e-mailu, který se posílá novým členům:',
+				'name'       => __( 'New member email settings:', 'simpleshop-cz' ),
 				'classes_cb' => [ $this, 'hide_when_invalid_keys' ],
 				'type'       => 'title',
 				'id'         => 'ssc_email_title',
@@ -173,26 +173,25 @@ class Settings {
 		);
 		$cmb->add_field(
 			[
-				'name'             => 'Poslat e-mail novému členovi?',
+				'name'             => __( 'Send email to new member?', 'simpleshop-cz' ),
 				'id'               => 'ssc_email_enable',
 				'type'             => 'select',
 				'show_option_none' => false,
 				'classes_cb'       => [ $this, 'hide_when_invalid_keys' ],
 				'default'          => '1',
 				'options'          => [
-					'1' => __( 'Yes, send email to new member.', 'cmb2', 'simpleshop.cz', 'simpleshop-cz' ),
-					'2' => __( 'No, don\'t send email to new members.', 'cmb2', 'simpleshop.cz', 'simpleshop-cz' ),
+					'1' => __( 'Yes, send email to new member.', 'simpleshop-cz' ),
+					'2' => __( 'No, don\'t send email to new members.', 'simpleshop-cz' ),
 				],
 			]
 		);
 		$cmb->add_field(
 			[
 				'name'       => __( 'Email subject', 'simpleshop-cz' ),
-//            'desc' => __('Najdete ho ve svém SimpleShop účtu v Nastavení -> WP Plugin','ssc'),
 				'id'         => 'ssc_email_subject',
 				'classes_cb' => [ $this, 'hide_when_invalid_keys' ],
 				'type'       => 'text',
-				'default'    => 'Byl Vám udělen přístup do členské sekce',
+				'default'    => __( 'You have been granted access to the member section', 'simpleshop-cz' ),
 			]
 		);
 
@@ -200,30 +199,31 @@ class Settings {
 		$cmb->add_field(
 			[
 				'name'       => __( 'Email message', 'simpleshop-cz' ),
-				'desc'       => __( '<u>Povolené zástupné znaky:</u><br/>'
-									. '<div style="font-style:normal;"><b>{login}</b> = login<br/>'
-									. '<b>{password}</b> = heslo<br/>'
-									. '<b>{login_url}</b> = adresa, na které je možné se přihlásit<br/>'
-									. '<b>{pages}</b> = seznam stránek, do kterých má uživatel zakoupený přístup<br/>'
-									. '<b>{mail}</b> = e-mail uživatele (většinou stejný jako login)<br/>'
-									. '</div>'
-									. '', 'simpleshop-cz' ),
+				'desc'       => __( '<u>Allowed patterns:</u><br/>'
+				                    . '<div style="font-style:normal;"><b>{login}</b> = login<br/>'
+				                    . '<b>{password}</b> = password<br/>'
+				                    . '<b>{login_url}</b> = URL address where User can login<br/>'
+				                    . '<b>{pages}</b> = list of pages to which the user has purchased access<br/>'
+				                    . '<b>{mail}</b> = user email (usually the same as login)<br/>'
+				                    . '</div>'
+					, 'simpleshop-cz' ),
 				'id'         => 'ssc_email_text',
 				'type'       => 'wysiwyg',
 				'classes_cb' => [ $this, 'hide_when_invalid_keys' ],
-				'default'    => 'Dobrý den,
-byl udělen přístup do členské sekce.
+				'default'    => sprintf( __( 'Dear customer,
+you have been granted access to the member section.
 
 Login: {login}
-Heslo: {password}
+Password: {password}
 
-Přihlásit se můžete na: ' . wp_login_url() . '
+You can sign in at: %s
 
-Váš zakoupený obsah:
+Your purchased content:
 {pages}
 
-S pozdravem a přáním pěkného dne,
-SimpleShop.cz - <i>S námi zvládne prodávat každý</i>',
+With regards,
+SimpleShop.cz - <i>Everyone can sell with us</i>'
+					, 'simpleshop-cz' ), wp_login_url() ),
 			]
 		);
 
@@ -233,9 +233,7 @@ SimpleShop.cz - <i>S námi zvládne prodávat každý</i>',
 		#
 		$cmb->add_field(
 			[
-				'name' => 'Nastavení API - propojení s aplikací SimpleShop:',
-//            'desc' => 'This is a title description',
-//            'show_on_cb' => array($this,'hide_when_invalid_keys'),
+				'name' => __( 'API settings – connection with SimpleShop application:', 'simpleshop-cz' ),
 				'type' => 'title',
 				'id'   => 'ssc_api_title',
 			]
@@ -254,7 +252,7 @@ SimpleShop.cz - <i>S námi zvládne prodávat každý</i>',
 		$cmb->add_field(
 			[
 				'name' => __( 'SimpleShop API Key', 'simpleshop-cz' ),
-				'desc' => __( 'You found it at SimpleShop in Settings (Nastavení) -> WP Plugin', 'simpleshop-cz' ),
+				'desc' => __( 'You found it at SimpleShop in Settings -> WP Plugin', 'simpleshop-cz' ),
 				'id'   => 'ssc_api_key',
 				'type' => 'text',
 			]
@@ -284,7 +282,7 @@ SimpleShop.cz - <i>S námi zvládne prodávat každý</i>',
 
 		$cmb->add_field(
 			[
-				'name'       => 'Obecná nastavení',
+				'name'       => __( 'General settings', 'simpleshop-cz' ),
 				'type'       => 'title',
 				'id'         => 'ssc_general_settings_title',
 				'classes_cb' => [ $this, 'hide_when_invalid_keys' ],
@@ -293,7 +291,7 @@ SimpleShop.cz - <i>S námi zvládne prodávat každý</i>',
 
 		$cmb->add_field(
 			[
-				'name'       => 'Přesměrování po přihlášení',
+				'name'       => __( 'Redirect after login', 'simpleshop-cz' ),
 				'type'       => 'text',
 				'id'         => 'ssc_redirect_url',
 				'classes_cb' => [ $this, 'hide_when_invalid_keys' ],
@@ -301,7 +299,7 @@ SimpleShop.cz - <i>S námi zvládne prodávat každý</i>',
 		);
 		$cmb->add_field(
 			[
-				'name'       => 'Přesměrování po přihlášení',
+				'name'       => __( 'Redirect after login', 'simpleshop-cz' ),
 				'type'       => 'text',
 				'id'         => 'ssc_redirect_url',
 				'classes_cb' => [ $this, 'hide_when_invalid_keys' ],
@@ -309,7 +307,7 @@ SimpleShop.cz - <i>S námi zvládne prodávat každý</i>',
 		);
 		$cmb->add_field(
 			[
-				'name'       => 'Odebrat zabezpečené z RSS',
+				'name'       => __( 'Remove secured items from RSS', 'simpleshop-cz' ),
 				'type'       => 'checkbox',
 				'id'         => 'ssc_hide_from_rss',
 				'classes_cb' => [ $this, 'hide_when_invalid_keys' ],
@@ -319,7 +317,7 @@ SimpleShop.cz - <i>S námi zvládne prodávat každý</i>',
 
 		$cmb->add_field(
 			[
-				'name'       => 'Odebrat propojení',
+				'name'       => __( 'Disconnect', 'simpleshop-cz' ),
 				'type'       => 'title',
 				'id'         => 'ssc_remove_api_title',
 				'classes_cb' => [ $this, 'hide_when_invalid_keys' ],
@@ -328,7 +326,7 @@ SimpleShop.cz - <i>S námi zvládne prodávat každý</i>',
 
 		$cmb->add_field(
 			[
-				'name'       => __( 'Disconnect Simple Shop', 'simpleshop-cz' ),
+				'name'       => __( 'Disconnect SimpleShop', 'simpleshop-cz' ),
 				'desc'       => __( 'You found it at SimpleShop in Settings (Nastavení) -> WP Plugin',
 					'simpleshop-cz' ),
 				'id'         => 'ssc_api_disconnect',
@@ -478,8 +476,7 @@ SimpleShop.cz - <i>S námi zvládne prodávat každý</i>',
 		return $val;
 	}
 
-	public function is_settings_page(  ) {
-        return is_admin() && !empty($_GET['page']) && 'ssc_options' === $_GET['page'];
+	public function is_settings_page() {
+		return is_admin() && ! empty( $_GET['page'] ) && 'ssc_options' === $_GET['page'];
 	}
-
 }


### PR DESCRIPTION
Opravy, zejména textové věci

- Oprava správného formátu slova `SimpleShop` (nikoliv `Simpleshop`, nebo `Simple shop`),
- Oprava správného formátu slova `WordPress` (nikoliv `Wordpress`),
- Oprava překladů,
- Doplnění chybějících

Prosím @vasikgreif o důslednou kontrolu oprav textací v `js/gutenberg/ss-gutenberg.js`, protože netuším, jestli mohu takto pracovat s JSX (nebo v čem to vlastně je psané…)