### PR TITLE
Readme: Fix minimal WP version (unite readme+plugin file header)

### DIFF
--- a/simpleshop-cz.php
+++ b/simpleshop-cz.php
@@ -14,7 +14,7 @@
  * Author URI: https://www.redbit.cz
  * Version: dev-master
  * Text Domain: simpleshop-cz
- * Requires at least: 4.6
+ * Requires at least: 5.0.0
  * Update URI: https://wordpress.org/plugins/simpleshop-cz/
  */
 


### PR DESCRIPTION
Oprava chybně uvedené minimální verze PHP, která by měla být v obou definicích stejná