### PR TITLE
Add nonce verification to SimpleShop disconnect feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6802,9 +6802,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "dev": true
     },
     "for-each": {

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -83,9 +83,15 @@ class Settings {
 		$object_type,
 		$field_type_object
 	) {
+		$url = add_query_arg( [
+			'_wpnonce'              => wp_create_nonce(),
+			'page'                  => 'ssc_options',
+			'disconnect_simpleshop' => 1,
+		], admin_url( 'admin.php' ) );
+
 		printf(
 			'<a href="%s">%s</a>',
-			htmlspecialchars( admin_url( 'admin.php?page=ssc_options&disconnect_simpleshop=1' ), ENT_QUOTES ),
+			htmlspecialchars( $url, ENT_QUOTES ),
 			__( 'Disconnect SimpleShop', 'simpleshop-cz' )
 		);
 	}
@@ -339,6 +345,10 @@ SimpleShop.cz - <i>Everyone can sell with us</i>'
 	 * Maybe delete the API keys
 	 */
 	public function maybe_disconnect_simpleshop() {
+		if ( ! wp_verify_nonce( $_GET['_wpnonce'] ) ) {
+			return;
+		}
+
 		if ( ! isset( $_GET['disconnect_simpleshop'] ) || $_GET['disconnect_simpleshop'] !== '1' ) {
 			return;
 		}

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -345,7 +345,7 @@ SimpleShop.cz - <i>Everyone can sell with us</i>'
 	 * Maybe delete the API keys
 	 */
 	public function maybe_disconnect_simpleshop() {
-		if ( ! wp_verify_nonce( $_GET['_wpnonce'] ) ) {
+		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( $_GET['_wpnonce'] ) ) {
 			return;
 		}
 
@@ -363,6 +363,8 @@ SimpleShop.cz - <i>Everyone can sell with us</i>'
 
 		// Update the SS options
 		update_option( $this->key, $options );
+		$url = add_query_arg( [ 'page' => 'ssc_options' ], admin_url( 'admin.php' ) );
+		wp_redirect( $url );
 	}
 
 	/**


### PR DESCRIPTION
The commit ensures security by adding nonce verification to the option to disconnect SimpleShop. Before this, the "Disconnect SimpleShop" link lacked this verification. Now, the option checks the '_wpnonce' query parameter with nonce before proceeding.